### PR TITLE
Add Tegra X1 / aarch64 support

### DIFF
--- a/carlsim/configure.mk
+++ b/carlsim/configure.mk
@@ -55,7 +55,7 @@ OSUPPER = $(shell uname -s 2>/dev/null | tr "[:lower:]" "[:upper:]")
 OSLOWER = $(shell uname -s 2>/dev/null | tr "[:upper:]" "[:lower:]")
 
 # Flags to detect 32-bit or 64-bit OS platform
-OS_SIZE = $(shell uname -m | sed -e "s/i.86/32/" -e "s/x86_64/64/" -e "s/armv7l/32/")
+OS_SIZE = $(shell uname -m | sed -e "s/i.86/32/" -e "s/x86_64/64/" -e "s/armv7l/32/" -e "s/aarch64/64/")
 OS_ARCH = $(shell uname -m | sed -e "s/i386/i686/")
 
 # search at Darwin (unix based info)


### PR DESCRIPTION
This PR closes #33, fixing nvcc fatal error on Tegra X1 (aarch64) platforms.